### PR TITLE
chore(ci): migrate from `macos-13` to `macos-15-intel` runner

### DIFF
--- a/.github/workflows/go118.yml
+++ b/.github/workflows/go118.yml
@@ -2,15 +2,13 @@ name: Go1.18
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
 
   macos:
     name: Test Go1.18 for macOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
 
     - name: Set up Go 1.18

--- a/.github/workflows/go119.yml
+++ b/.github/workflows/go119.yml
@@ -2,15 +2,13 @@ name: Go1.19
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
 
   macos:
     name: Test Go1.19 for macOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
 
     - name: Set up Go 1.19

--- a/.github/workflows/go120.yml
+++ b/.github/workflows/go120.yml
@@ -2,15 +2,13 @@ name: Go1.20
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
 
   macos:
     name: Test Go1.20 for macOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
 
     - name: Set up Go 1.20

--- a/.github/workflows/go121.yml
+++ b/.github/workflows/go121.yml
@@ -2,15 +2,13 @@ name: Go1.21
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
 
   macos:
     name: Test Go1.21 for macOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
 
     - name: Set up Go 1.21

--- a/.github/workflows/go122.yml
+++ b/.github/workflows/go122.yml
@@ -2,15 +2,13 @@ name: Go1.22
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
 
   macos:
     name: Test Go1.22 for macOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
 
     - name: Set up Go 1.22

--- a/.github/workflows/go123.yml
+++ b/.github/workflows/go123.yml
@@ -2,15 +2,13 @@ name: Go1.23
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
 
   macos:
     name: Test Go1.23 for macOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
 
     - name: Set up Go 1.23

--- a/.github/workflows/go124.yml
+++ b/.github/workflows/go124.yml
@@ -2,15 +2,13 @@ name: Go1.24
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
 
   macos:
     name: Test Go1.24 for macOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
 
     - name: Set up Go 1.24

--- a/.github/workflows/go125.yml
+++ b/.github/workflows/go125.yml
@@ -2,15 +2,13 @@ name: Go1.25
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
 
   macos:
     name: Test Go1.25 for macOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
 
     - name: Set up Go 1.25


### PR DESCRIPTION
GitHub announced the deprecation of the `macos-13` runner image[^1], which will be completely removed by December 4th, 2025.

This commit migrates all workflows to use `macos-15-intel` runners following the announcement's recommendation.

[^1]: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/