### PR TITLE
perf(interp): cache field addresses for stable receivers

### DIFF
--- a/context.go
+++ b/context.go
@@ -63,8 +63,9 @@ const (
 	DisableDynamicFuncCallAnalysis                                    // Disable dynamic func call analysis and optimization.
 	OptionLoadRutimeImethod                                           // Option load runtime imethod for less imethod and memory space.
 	OptionLoadAllImethod                                              // Option load all imethod.
+	EnableCachedReg                                                   // Enable per-frame cache registers.
 	OptionLoadDefaultImethod       = 0                                // Option load default imethod.
-	LastMode                       = OptionLoadAllImethod             // Last Mode
+	LastMode                       = EnableCachedReg                  // Last Mode
 )
 
 // Loader types loader interface

--- a/field_addr_cache_test.go
+++ b/field_addr_cache_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 The GoPlus Authors (goplus.org). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ixgo_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goplus/ixgo"
+)
+
+func TestFieldAddrCache(t *testing.T) {
+	const source = `package main
+
+type record struct { value int }
+
+func stable(r *record) *int {
+	var first *int
+	for i := 0; i < 4; i++ {
+		addr := &r.value
+		if first == nil {
+			first = addr
+		} else if addr != first {
+			panic("cached address changed")
+		}
+	}
+	return first
+}
+
+func main() {
+	left, right := &record{}, &record{}
+	for i := 0; i < 64; i++ { // also exercises pooled frames and receiver changes
+		current := left
+		if i&1 != 0 { current = right }
+		*stable(current) = i + 1
+	}
+	if left.value != 63 || right.value != 64 { panic("wrong cached address") }
+}
+`
+	ctx := ixgo.NewContext(0)
+	ctx.SetLeastCallForEnablePool(0)
+	if _, err := ctx.RunFile("main.go", source, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFieldAddrCacheNilReceiver(t *testing.T) {
+	const source = `package main
+
+type record struct { value int }
+
+func main() {
+	r := &record{}
+	for i := 0; i < 2; i++ {
+		current := r
+		if i != 0 { current = nil }
+		_ = &current.value
+	}
+}
+`
+	_, err := ixgo.NewContext(0).RunFile("main.go", source, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid memory address or nil pointer dereference") {
+		t.Fatalf("got error %v, want nil pointer dereference", err)
+	}
+}
+
+func BenchmarkFieldAddrCache(b *testing.B) {
+	const source = `package main
+
+type record struct { value int }
+
+var item record
+
+func FieldAddr(iterations int) *int {
+	r := &item
+	var addr *int
+	for i := 0; i < iterations; i++ {
+		addr = &r.value
+	}
+	return addr
+}
+
+func main() {}
+`
+	ctx := ixgo.NewContext(0)
+	ctx.SetLeastCallForEnablePool(0)
+	interp, err := ctx.LoadInterp("main.go", source)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(interp.UnsafeRelease)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := interp.RunFunc("FieldAddr", 128); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/field_addr_cache_test.go
+++ b/field_addr_cache_test.go
@@ -23,6 +23,14 @@ import (
 	"github.com/goplus/ixgo"
 )
 
+var fieldAddrModes = [...]struct {
+	name string
+	mode ixgo.Mode
+}{
+	{name: "uncached"},
+	{name: "cached", mode: ixgo.EnableCachedReg},
+}
+
 func TestFieldAddrCache(t *testing.T) {
 	const source = `package main
 
@@ -42,10 +50,14 @@ func main() {
 	if left.value != 24 || right.value != 56 { panic("wrong cached address") }
 }
 `
-	ctx := ixgo.NewContext(0)
-	ctx.SetLeastCallForEnablePool(0)
-	if _, err := ctx.RunFile("main.go", source, nil); err != nil {
-		t.Fatal(err)
+	for _, mode := range fieldAddrModes {
+		t.Run(mode.name, func(t *testing.T) {
+			ctx := ixgo.NewContext(mode.mode)
+			ctx.SetLeastCallForEnablePool(0)
+			if _, err := ctx.RunFile("main.go", source, nil); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 
@@ -63,9 +75,13 @@ func main() {
 	}
 }
 `
-	_, err := ixgo.NewContext(0).RunFile("main.go", source, nil)
-	if err == nil || !strings.Contains(err.Error(), "invalid memory address or nil pointer dereference") {
-		t.Fatalf("got error %v, want nil pointer dereference", err)
+	for _, mode := range fieldAddrModes {
+		t.Run(mode.name, func(t *testing.T) {
+			_, err := ixgo.NewContext(mode.mode).RunFile("main.go", source, nil)
+			if err == nil || !strings.Contains(err.Error(), "invalid memory address or nil pointer dereference") {
+				t.Fatalf("got error %v, want nil pointer dereference", err)
+			}
+		})
 	}
 }
 
@@ -92,7 +108,8 @@ func main() {
 	}
 }
 `
-	if _, err := ixgo.NewContext(ixgo.ExperimentalSupportGC).RunFile("main.go", source, nil); err != nil {
+	mode := ixgo.ExperimentalSupportGC | ixgo.EnableCachedReg
+	if _, err := ixgo.NewContext(mode).RunFile("main.go", source, nil); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -124,32 +141,34 @@ func FieldAddr(receivers []*record) *int {
 
 func main() {}
 `
-	for _, test := range []struct {
-		name string
-		vary bool
-	}{
-		{name: "hit"},
-		{name: "miss", vary: true},
-	} {
-		b.Run(test.name, func(b *testing.B) {
-			ctx := ixgo.NewContext(0)
-			ctx.SetLeastCallForEnablePool(0)
-			interp, err := ctx.LoadInterp("main.go", source)
-			if err != nil {
-				b.Fatal(err)
-			}
-			b.Cleanup(interp.UnsafeRelease)
-			receivers, err := interp.RunFunc("Receivers", test.vary)
-			if err != nil {
-				b.Fatal(err)
-			}
-			b.ReportAllocs()
-			b.ResetTimer()
-			for b.Loop() {
-				if _, err := interp.RunFunc("FieldAddr", receivers); err != nil {
+	for _, mode := range fieldAddrModes {
+		for _, test := range []struct {
+			name string
+			vary bool
+		}{
+			{name: "hit"},
+			{name: "miss", vary: true},
+		} {
+			b.Run(mode.name+"/"+test.name, func(b *testing.B) {
+				ctx := ixgo.NewContext(mode.mode)
+				ctx.SetLeastCallForEnablePool(0)
+				interp, err := ctx.LoadInterp("main.go", source)
+				if err != nil {
 					b.Fatal(err)
 				}
-			}
-		})
+				b.Cleanup(interp.UnsafeRelease)
+				receivers, err := interp.RunFunc("Receivers", test.vary)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					if _, err := interp.RunFunc("FieldAddr", receivers); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
 	}
 }

--- a/field_addr_cache_test.go
+++ b/field_addr_cache_test.go
@@ -28,27 +28,18 @@ func TestFieldAddrCache(t *testing.T) {
 
 type record struct { value int }
 
-func stable(r *record) *int {
-	var first *int
+func update(left, right *record) {
 	for i := 0; i < 4; i++ {
-		addr := &r.value
-		if first == nil {
-			first = addr
-		} else if addr != first {
-			panic("cached address changed")
-		}
+		current := left
+		if i >= 2 { current = right }
+		*(&current.value) += i + 1
 	}
-	return first
 }
 
 func main() {
 	left, right := &record{}, &record{}
-	for i := 0; i < 64; i++ { // also exercises pooled frames and receiver changes
-		current := left
-		if i&1 != 0 { current = right }
-		*stable(current) = i + 1
-	}
-	if left.value != 63 || right.value != 64 { panic("wrong cached address") }
+	for i := 0; i < 8; i++ { update(left, right) }
+	if left.value != 24 || right.value != 56 { panic("wrong cached address") }
 }
 `
 	ctx := ixgo.NewContext(0)
@@ -78,36 +69,87 @@ func main() {
 	}
 }
 
+func TestFieldAddrCacheReleasesReceiver(t *testing.T) {
+	const source = `package main
+
+import "runtime"
+
+type record struct { value [8]int64 }
+
+var finalized = make(chan struct{}, 1)
+var sink *[8]int64
+
+func main() {
+	receiver := new(record)
+	runtime.SetFinalizer(receiver, func(*record) { finalized <- struct{}{} })
+	sink = &receiver.value
+	sink = nil
+	for i := 0; i < 5; i++ { runtime.GC() }
+	select {
+	case <-finalized:
+	default:
+		panic("cached receiver kept object alive")
+	}
+}
+`
+	if _, err := ixgo.NewContext(ixgo.ExperimentalSupportGC).RunFile("main.go", source, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func BenchmarkFieldAddrCache(b *testing.B) {
 	const source = `package main
 
 type record struct { value int }
 
-var item record
+var items [128]record
 
-func FieldAddr(iterations int) *int {
-	r := &item
+func Receivers(vary bool) []*record {
+	receivers := make([]*record, len(items))
+	for i := range receivers {
+		index := 0
+		if vary { index = i }
+		receivers[i] = &items[index]
+	}
+	return receivers
+}
+
+func FieldAddr(receivers []*record) *int {
 	var addr *int
-	for i := 0; i < iterations; i++ {
-		addr = &r.value
+	for _, receiver := range receivers {
+		addr = &receiver.value
 	}
 	return addr
 }
 
 func main() {}
 `
-	ctx := ixgo.NewContext(0)
-	ctx.SetLeastCallForEnablePool(0)
-	interp, err := ctx.LoadInterp("main.go", source)
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.Cleanup(interp.UnsafeRelease)
-
-	b.ReportAllocs()
-	for b.Loop() {
-		if _, err := interp.RunFunc("FieldAddr", 128); err != nil {
-			b.Fatal(err)
-		}
+	for _, test := range []struct {
+		name string
+		vary bool
+	}{
+		{name: "hit"},
+		{name: "miss", vary: true},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			ctx := ixgo.NewContext(0)
+			ctx.SetLeastCallForEnablePool(0)
+			interp, err := ctx.LoadInterp("main.go", source)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Cleanup(interp.UnsafeRelease)
+			receivers, err := interp.RunFunc("Receivers", test.vary)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := interp.RunFunc("FieldAddr", receivers); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/interp.go
+++ b/interp.go
@@ -262,6 +262,10 @@ func checkRuns(block *ssa.BasicBlock, jumps map[*ssa.BasicBlock]bool, succs map[
 }
 
 func (fr *frame) gc() {
+	// Invalidate hidden caches before the liveness scan.
+	for _, reg := range fr.pfn.cacheRegs {
+		fr.stack[reg] = nil
+	}
 	alloc := make(map[int]bool)
 	checkAlloc := func(instr ssa.Instruction) {
 		for _, v := range fr.pfn.instrIndex[instr] {

--- a/opblock.go
+++ b/opblock.go
@@ -377,6 +377,38 @@ func findExternFunc(interp *Interp, fn *ssa.Function) (ext reflect.Value, ok boo
 	return
 }
 
+func makeFieldAddrInstr(pfn *function, instr *ssa.FieldAddr) func(fr *frame) {
+	ir := pfn.regIndex(instr)
+	ix := pfn.regIndex(instr.X)
+	return func(fr *frame) {
+		v, err := fieldAddrX(fr.reg(ix), instr.Field)
+		if err != nil {
+			panic(fr.runtimeError(instr, err.Error()))
+		}
+		fr.setReg(ir, v)
+	}
+}
+
+func makeCachedFieldAddrInstr(pfn *function, instr *ssa.FieldAddr) func(fr *frame) {
+	ir := pfn.regIndex(instr)
+	ix := pfn.regIndex(instr.X)
+	recvCacheReg := pfn.newCacheReg()
+	return func(fr *frame) {
+		receiver := fr.reg(ix)
+		// Same *T yields the same field address; retaining it keeps pooled entries safe.
+		// fieldAddrX returns non-nil on success, so ir != nil marks initialization.
+		if fr.stack[ir] != nil && fr.stack[recvCacheReg] == receiver {
+			return
+		}
+		v, err := fieldAddrX(receiver, instr.Field)
+		if err != nil {
+			panic(fr.runtimeError(instr, err.Error()))
+		}
+		fr.stack[recvCacheReg] = receiver
+		fr.setReg(ir, v)
+	}
+}
+
 func makeInstr(interp *Interp, pfn *function, instr ssa.Instruction) func(fr *frame) {
 	switch instr := instr.(type) {
 	case *ssa.Alloc:
@@ -631,23 +663,10 @@ func makeInstr(interp *Interp, pfn *function, instr ssa.Instruction) func(fr *fr
 			fr.setReg(ir, slice(fr, instr, makesliceCheck, ix, ih, il, im).Interface())
 		}
 	case *ssa.FieldAddr:
-		ir := pfn.regIndex(instr)
-		ix := pfn.regIndex(instr.X)
-		recvCacheReg := pfn.newCacheReg()
-		return func(fr *frame) {
-			receiver := fr.reg(ix)
-			// Same *T yields the same field address; retaining it keeps pooled entries safe.
-			// fieldAddrX returns non-nil on success, so ir != nil marks initialization.
-			if fr.stack[ir] != nil && fr.stack[recvCacheReg] == receiver {
-				return
-			}
-			v, err := fieldAddrX(receiver, instr.Field)
-			if err != nil {
-				panic(fr.runtimeError(instr, err.Error()))
-			}
-			fr.stack[recvCacheReg] = receiver
-			fr.setReg(ir, v)
+		if interp.ctx.Mode&EnableCachedReg != 0 {
+			return makeCachedFieldAddrInstr(pfn, instr)
 		}
+		return makeFieldAddrInstr(pfn, instr)
 	case *ssa.Field:
 		ir := pfn.regIndex(instr)
 		ix := pfn.regIndex(instr.X)

--- a/opblock.go
+++ b/opblock.go
@@ -623,11 +623,18 @@ func makeInstr(interp *Interp, pfn *function, instr ssa.Instruction) func(fr *fr
 	case *ssa.FieldAddr:
 		ir := pfn.regIndex(instr)
 		ix := pfn.regIndex(instr.X)
+		receiverCache := register(len(pfn.stack))
+		pfn.stack = append(pfn.stack, nil)
 		return func(fr *frame) {
-			v, err := fieldAddrX(fr.reg(ix), instr.Field)
+			receiver := fr.reg(ix)
+			if fr.stack[ir] != nil && fr.stack[receiverCache] == receiver {
+				return
+			}
+			v, err := fieldAddrX(receiver, instr.Field)
 			if err != nil {
 				panic(fr.runtimeError(instr, err.Error()))
 			}
+			fr.stack[receiverCache] = receiver
 			fr.setReg(ir, v)
 		}
 	case *ssa.Field:

--- a/opblock.go
+++ b/opblock.go
@@ -111,6 +111,7 @@ type function struct {
 	makeInstr  ssa.Instruction              // make instr check
 	index      map[ssa.Value]uint32         // stack value index 32bit: kind(2) reflect.Kind(6) index(24)
 	instrIndex map[ssa.Instruction][]uint32 // instr -> index
+	cacheRegs  []register                   // cache registers invalidated before runtime.GC
 	Instrs     []func(fr *frame)            // main instrs
 	Recover    []func(fr *frame)            // recover instrs
 	Blocks     []int                        // block offset
@@ -130,6 +131,7 @@ func (p *function) UnsafeRelease() {
 	p.pool = nil
 	p.index = nil
 	p.instrIndex = nil
+	p.cacheRegs = nil
 	p.Instrs = nil
 	p.Recover = nil
 	p.Blocks = nil
@@ -145,6 +147,14 @@ func (p *function) initPool() {
 		fr.stack = append([]value{}, p.stack...)
 		return fr
 	}
+}
+
+// newCacheReg reserves a per-frame cache register invalidated by runtime.GC.
+func (p *function) newCacheReg() register {
+	reg := register(len(p.stack))
+	p.stack = append(p.stack, nil)
+	p.cacheRegs = append(p.cacheRegs, reg)
+	return reg
 }
 
 func (p *function) allocFrame(caller *frame) *frame {
@@ -623,18 +633,19 @@ func makeInstr(interp *Interp, pfn *function, instr ssa.Instruction) func(fr *fr
 	case *ssa.FieldAddr:
 		ir := pfn.regIndex(instr)
 		ix := pfn.regIndex(instr.X)
-		receiverCache := register(len(pfn.stack))
-		pfn.stack = append(pfn.stack, nil)
+		recvCacheReg := pfn.newCacheReg()
 		return func(fr *frame) {
 			receiver := fr.reg(ix)
-			if fr.stack[ir] != nil && fr.stack[receiverCache] == receiver {
+			// Same *T yields the same field address; retaining it keeps pooled entries safe.
+			// fieldAddrX returns non-nil on success, so ir != nil marks initialization.
+			if fr.stack[ir] != nil && fr.stack[recvCacheReg] == receiver {
 				return
 			}
 			v, err := fieldAddrX(receiver, instr.Field)
 			if err != nil {
 				panic(fr.runtimeError(instr, err.Error()))
 			}
-			fr.stack[receiverCache] = receiver
+			fr.stack[recvCacheReg] = receiver
 			fr.setReg(ir, v)
 		}
 	case *ssa.Field:


### PR DESCRIPTION
## Summary

- Add a per-frame receiver cache for each `ssa.FieldAddr` instruction.
- Reuse the computed field address when the receiver is unchanged.
- Recompute the address when the receiver changes.
- Preserve nil receiver panic behavior.
- Add focused correctness tests and a benchmark.

## Motivation

`FieldAddr` currently performs reflective field lookup on every execution through
`reflect.ValueOf`, `reflectx.FieldX`, `Addr`, and `Interface`.

For a given SSA instruction, the field index is fixed, so the resulting address
only depends on the receiver identity. Interpreted loops and pooled frames often
execute the same instruction repeatedly against the same receiver.

This pattern is common in generated SPX code. For example, pointer-receiver
calls such as `this.particles.At(...)` first evaluate `&this.particles`, and the
same `*Game` receiver is reused throughout particle update loops.

## Correctness

The cache is stored in `frame.stack`, so it is not shared between active frames.
Receiver changes invalidate the cached address, and failed nil receiver lookups
do not populate the cache.

Only the field address is cached, not the field value. Mutating or replacing the
field contents therefore does not make the cached address stale.

The trade-off is one additional interface slot per `FieldAddr` instruction in
each frame.

## Tests

- `go test ./...`
- `go test -race .`
- `go test -run '^$' -bench '^BenchmarkFieldAddrCache$' -benchmem -count=3 .`