### PR TITLE
directcall: register syslog adapters

### DIFF
--- a/directcall/syslog.go
+++ b/directcall/syslog.go
@@ -1,0 +1,8 @@
+//go:build !windows && !plan9
+// +build !windows,!plan9
+
+package directcall
+
+import (
+	_ "github.com/goplus/ixgo/directcall/log/syslog"
+)


### PR DESCRIPTION
## Summary

- Register generated `log/syslog` direct-call adapters from the root package on supported platforms.

## Testing

- `go test ./directcall ./directcall/log/syslog`